### PR TITLE
Add run on repl.it badge to README

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,2 @@
+language = "reactjs"
+run = "run"

--- a/README.md
+++ b/README.md
@@ -189,3 +189,5 @@ Dribbble: <https://dribbble.com/creativetim>
 Google+: <https://plus.google.com/+CreativetimPage>
 
 Instagram: <https://instagram.com/creativetimofficial>
+
+[![Run on Repl.it](https://repl.it/badge/github/creativetimofficial/black-dashboard-react)](https://repl.it/github/creativetimofficial/black-dashboard-react)


### PR DESCRIPTION
This pull request configures this repository to be run on Repl.it.      It adds a `.replit` configuration file and a Repl.it badge to the `README`.
     You can read more about running repos on Repl.it [here](https://docs.repl.it/repls/dot-replit), or view the Repl [here](https://repl.it/@raywick/black-dashboard-react).